### PR TITLE
Fix block linking

### DIFF
--- a/src/main/java/org/crypto/chain/BlockFactory.java
+++ b/src/main/java/org/crypto/chain/BlockFactory.java
@@ -17,7 +17,11 @@ public class BlockFactory {
 
     public void createNewBlock(Blockchain blockchain) throws Exception {
         if (Input.getUserInput("Would you like to add some data?").equals("y")) {
-            blockchain.add(new Block(Input.getUserInput("Please add some data for the block"), null, new Date()));
+            String previousHash = null;
+            if (blockchain.getBlockchainSize() > 0) {
+                previousHash = blockchain.getBlock(blockchain.getBlockchainSize() - 1).getHash();
+            }
+            blockchain.add(new Block(Input.getUserInput("Please add some data for the block"), previousHash, new Date()));
         } else {
             return;
         }


### PR DESCRIPTION
## Summary
- link blocks by using previous block's hash when creating new blocks

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684574181dd48327b100e91a800fc67c